### PR TITLE
workflow: use actions/setup-node

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,18 +6,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+    - name: Setup
+      uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+    - name: Install
+      run: npm ci
     - name: Build
-      uses: actions/npm@master
-      with:
-        args: ci
+      run: npm run build
     - name: Test
-      uses: actions/npm@master
-      with:
-        args: test
+      run: npm test
     - name: Publish
       if: github.event_name == 'release' && github.event.action == 'created'
-      uses: actions/npm@master
       env:
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-      with:
-        args: publish --access public
+      run: publish --access public


### PR DESCRIPTION
Use actions/setup-node as actions/npm is apparently deprecated and exits
1: https://github.com/wmde/vuex-helpers/runs/254025692
It's a win that this now references a versioned action

Publishing (a scoped package) may or may not become a problem this way:
https://github.com/actions/setup-node/issues/52

This adds an actual build, so we catch failure to compile during CI, not
only when trying to publish (via prepublishOnly).

See https://github.com/actions/setup-node#usage