### PR TITLE
workflow: specify npm binary when publishing

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,4 +20,4 @@ jobs:
       if: github.event_name == 'release' && github.event.action == 'created'
       env:
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-      run: publish --access public
+      run: npm publish --access public


### PR DESCRIPTION
This was missed in d3d5c76 - sorry.

We may still have the conditions wrong (not really published ever since converted to the YAML syntax) as this step does not even seem to have been run.