### PR TITLE
Release workflow with separate publish job

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,5 +23,5 @@ jobs:
     - name: Publish
       if: github.event_name == 'release' && github.event.action == 'created'
       env:
-        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
       run: npm publish --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,11 @@
-on: push
-name: Build and Test
+on:
+  release:
+    types: [ created ]
+
+name: Verify and Publish
 jobs:
-  build:
-    name: Build
+  publish:
+    name: Publish
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
@@ -16,3 +19,7 @@ jobs:
       run: npm run build
     - name: Test
       run: npm test
+    - name: Publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      run: npm publish --access public


### PR DESCRIPTION
Pass the secret correctly.

Don't run on all [types of releases](https://help.github.com/en/articles/workflow-syntax-for-github-actions#onevent_nametypes) to reduce the [amount of jobs run](https://github.com/wmde/vuex-helpers/runs/255130479).