### PR TITLE
Explicitly define the registry when publishing npm release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,4 +22,4 @@ jobs:
     - name: Publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-      run: npm publish --access public
+      run: npm publish --access public --@wmde:registry=https://registry.npmjs.org/


### PR DESCRIPTION
Random attempt to fix issues with npm publishing. 
Inspired by https://github.com/actions/setup-node/issues/52#issuecomment-536544414. No idea if it even has a slight chance to work.

Alternative would likely be to overwrite `.npmrc` to contain npm auth token, as proved to work in https://github.com/vega/vega-lite/blob/7ba383fb2c8c2a8b5d1252c2061aaeef232484bb/.github/workflows/release.yml#L45 / https://github.com/wmde/vuex-helpers/pull/11#issuecomment-540718384